### PR TITLE
Refactor PlaylistView 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,10 +37,10 @@ playground.xcworkspace
 # Swift Package Manager
 #
 # Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
-# Packages/
-# Package.pins
-# Package.resolved
-# *.xcodeproj
+Packages/
+Package.pins
+Package.resolved
+*.xcodeproj
 #
 # Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
 # hence it is not needed unless you have added a package configuration file to your project
@@ -57,7 +57,7 @@ playground.xcworkspace
 # Pods/
 #
 # Add this line if you want to avoid checking in source code from the Xcode workspace
-# *.xcworkspace
+*.xcworkspace
 
 # Carthage
 #
@@ -88,3 +88,6 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+
+*.entitlements
+*.xcscheme

--- a/My Spot/ContentView.swift
+++ b/My Spot/ContentView.swift
@@ -88,7 +88,7 @@ struct ContentView: View {
             mySpotTab
             discoverTab
             addSpotTab
-            playlistTab
+            playlistTab()
             profileTab
         }
         .onChange(of: cloudViewModel.isSignedInToiCloud) { signedIn in
@@ -181,8 +181,9 @@ struct ContentView: View {
             .tag(Tab.addSpot)
     }
     
-    private var playlistTab: some View {
-        PlaylistView()
+    private func playlistTab() -> some View {
+        let viewModel = PlaylistViewModel(mapViewModel: mapViewModel, cloudViewModel: cloudViewModel)
+        return PlaylistView(viewModel: viewModel, factory: PlaylistSubviewsFactory(viewModel: viewModel))
             .tabItem() {
                 Image(systemName: "books.vertical")
                 Text("Playlists".localized())

--- a/My Spot/Model/CoreDataManager.swift
+++ b/My Spot/Model/CoreDataManager.swift
@@ -20,6 +20,8 @@ final class CoreDataStack: ObservableObject {
     var recievedShare = false
     var wasSuccessful = false
     
+    @Published var playlists = [Playlist]()
+    
     var ckContainer: CKContainer {
         let storeDescription = persistentContainer.persistentStoreDescriptions.first
         guard let identifier = storeDescription?.cloudKitContainerOptions?.containerIdentifier else {
@@ -268,4 +270,5 @@ extension CoreDataStack {
         }
         return isShared
     }
+    
 }

--- a/My Spot/Model/PlaylistPersistenceManager.swift
+++ b/My Spot/Model/PlaylistPersistenceManager.swift
@@ -1,0 +1,59 @@
+//
+//  PlaylistPersistence.swift
+//  My Spot
+//
+//  Created by Raphael Monteiro on 28/06/22.
+//
+
+import Foundation
+import CoreData
+import os.log
+
+/// Manages Playlist entity local and cloud persistence.
+final class PlaylistPersistenceManager: ObservableObject {
+    
+    @Published var playlists = [Playlist]()
+    let context = CoreDataStack.shared.context
+    let logger = Logger(subsystem: "mySpot", category: "PlaylistPersistenceManager")
+    
+    init() {
+        loadPlaylists()
+    }
+    
+    func loadPlaylists() {
+            let fetchRequest: NSFetchRequest<Playlist> = Playlist.fetchRequest()
+            do {
+                playlists = try context.fetch(fetchRequest)
+            } catch {
+                logger.error("\(error.localizedDescription)")
+            }
+    }
+    
+    func savePlaylist(name: String, emoji: String) {
+            let newPlaylist = Playlist(context: context)
+            newPlaylist.id = UUID()
+            newPlaylist.name = name
+            newPlaylist.emoji = emoji
+            saveContext()
+    }
+    
+    private func saveContext() {
+        if context.hasChanges {
+            do {
+                try context.save()
+                loadPlaylists()
+            } catch {
+                logger.error("\(error.localizedDescription)")
+            }
+        }
+    }
+    
+    func delete(_ playlist: Playlist) {
+        context.perform {
+            self.context.delete(playlist)
+            self.saveContext()
+        }
+    }
+    
+}
+

--- a/My Spot/View/Main View/PlaylistView.swift
+++ b/My Spot/View/Main View/PlaylistView.swift
@@ -14,165 +14,32 @@ import SwiftUI
 
 struct PlaylistView: View {
     
-    @FetchRequest(sortDescriptors: [SortDescriptor(\.name)]) var playlists: FetchedResults<Playlist>
-    @EnvironmentObject var mapViewModel: MapViewModel
-    @EnvironmentObject var cloudViewModel: CloudKitViewModel
-    @State private var presentDeleteAlert = false
-    @State private var presentAddPlaylistSheet = false
-    @State private var presentNoPermissionsAlert = false
-    @State private var toBeDeleted: IndexSet?
+    @ObservedObject var viewModel: PlaylistViewModel
+    var factory: PlaylistSubviewsFactory
     
     var body: some View {
         NavigationView {
             ZStack {
-                List {
-                    listPlaylists
-                }
-                .onAppear {
-                    resetBadges()
-                }
-                .navigationTitle("Playlists".localized())
-                .navigationBarTitleDisplayMode(.inline)
-                .toolbar {
-                    ToolbarItemGroup(placement: .navigationBarTrailing) {
-                        addPlaylistButton
+                factory.makeListPlaylists()
+                    .navigationTitle("Playlists".localized())
+                    .navigationBarTitleDisplayMode(.inline)
+                    .toolbar {
+                        ToolbarItemGroup(placement: .navigationBarTrailing) {
+                            factory.makeAddPlaylistButton()
+                        }
                     }
-                }
-                if playlists.count == 0 {
-                    noPlaylistPrompt
-                }
-            }
-            .sheet(isPresented: $presentAddPlaylistSheet) {
-                AddPlaylistSheet()
-            }
-            .alert("Invalid Permission".localized(), isPresented: $presentNoPermissionsAlert) {
-                Button("OK".localized(), role: .cancel) { }
-            } message: {
-                Text("Only the owner can delete. If you would like to leave the shared playlist, please tap the person icon and choose yourself.".localized())
-            }
-        }
-        .navigationViewStyle(.automatic)
-    }
-    
-    // MARK: - Sub Views
-    
-    private var listPlaylists: some View {
-        ForEach(playlists) { playlist in
-            NavigationLink(destination: DetailPlaylistView(playlist: playlist)) {
-                PlaylistRow(playlist: playlist,
-                            isShared: hasOnePart(playlist: playlist),
-                            isSharing: isSharing(playlist: playlist))
-                    .alert(isPresented: self.$presentDeleteAlert) {
-                        removePlaylistAlert
-                    }
-            }
-        }
-        .onDelete(perform: deleteRow)
-    }
-    
-    private var addPlaylistButton: some View {
-        Button {
-            presentAddPlaylistSheet.toggle()
-        } label: {
-            Image(systemName: "plus").imageScale(.large)
-        }
-    }
-    
-    private var noPlaylistPrompt: some View {
-        VStack(spacing: 6) {
-            noPlaylistPromptTitle
-            noPlaylistPromptSubtitle
-        }
-    }
-    
-    private var noPlaylistPromptTitle: some View {
-        HStack {
-            Spacer()
-            Text("No Playlists Here Yet!".localized())
-            Spacer()
-        }
-    }
-    
-    private var noPlaylistPromptSubtitle: some View {
-        HStack {
-            Spacer()
-            HStack {
-                Text("Add Some With The".localized())
-                    .font(.subheadline)
-                    .foregroundColor(.gray)
-                Image(systemName: "plus")
-                    .font(.subheadline)
-                    .foregroundColor(.gray)
-                Text("Button Above".localized())
-                    .font(.subheadline)
-                    .foregroundColor(.gray)
-            }
-            Spacer()
-        }
-    }
-    
-    private var removePlaylistAlert: Alert {
-        Alert(title: Text("Are you sure you want to delete?".localized()),
-              message: Text("If you are the owner of a shared playlist, all participants will no longer have access.".localized()),
-              primaryButton: .destructive(Text("Delete".localized())) {
-            self.delete(at: self.toBeDeleted!)
-            self.toBeDeleted = nil
-        }, secondaryButton: .cancel() {
-            self.toBeDeleted = nil
-        }
-        )
-    }
-    
-    // MARK: - Functions
-    
-    private func resetBadges() {
-        UserDefaults.standard.set(0, forKey: "badgeplaylists")
-        cloudViewModel.resetBadgePlaylists()
-    }
-    
-    private func hasOnePart(playlist: Playlist) -> Bool {
-        var isShared = false
-        if CoreDataStack.shared.isShared(object: playlist) {
-            let share = CoreDataStack.shared.getShare(playlist)
-            share?.participants.forEach { participant in
-                if (participant.acceptanceStatus == .accepted && participant.role != .owner) {
-                    isShared = true
+                if viewModel.persistence.playlists.count == 0 {
+                    factory.makeNoPlaylistPrompt()
                 }
             }
-        }
-        return isShared
-    }
-    
-    private func isSharing(playlist: Playlist) -> Bool {
-        return CoreDataStack.shared.isShared(object: playlist)
-    }
-    
-    private func deleteRow(at indexSet: IndexSet) {
-        self.toBeDeleted = indexSet
-        self.presentDeleteAlert = true
-        let generator = UINotificationFeedbackGenerator()
-        generator.notificationOccurred(.warning)
-    }
-    
-    private func delete(at offsets: IndexSet) {
-        let generator = UINotificationFeedbackGenerator()
-        generator.notificationOccurred(.warning)
-        offsets.forEach { i in
-            if !CoreDataStack.shared.isShared(object: playlists[i]) {
-                if (playlists[i].spotArr.count > 0) {
-                    for place in playlists[i].spotArr {
-                        place.playlist = nil
-                    }
-                }
-                CoreDataStack.shared.delete(playlists[i])
-            } else if CoreDataStack.shared.isOwner(object: playlists[i]) {
-                CoreDataStack.shared.delete(playlists[i])
-            } else {
-                let generator = UINotificationFeedbackGenerator()
-                generator.notificationOccurred(.error)
-                presentNoPermissionsAlert = true
+            .sheet(isPresented: $viewModel.presentAddPlaylistSheet) {
+                AddPlaylistSheet(viewModel: viewModel)
             }
-            return
+            .alert(isPresented: $viewModel.presentNoPermissionsAlert) {
+                factory.makeAlertInvalidPermission()
+            }
+            .navigationViewStyle(.automatic)
         }
     }
+    
 }

--- a/My Spot/View/Sub View/Playlist/AddPlaylistSheet.swift
+++ b/My Spot/View/Sub View/Playlist/AddPlaylistSheet.swift
@@ -21,6 +21,7 @@ struct AddPlaylistSheet: View {
     @State private var emoji = ""
     @State private var isEmoji: Bool = true
     @FocusState private var focusState: Field?
+    @ObservedObject var viewModel: PlaylistViewModel
     
     private var disableSave: Bool {
         name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
@@ -50,7 +51,7 @@ struct AddPlaylistSheet: View {
                     saveButton
                 }
                 ToolbarItemGroup(placement: .navigationBarLeading) {
-                    deleteButton
+                    cancelButton
                 }
             }
         }
@@ -109,9 +110,15 @@ struct AddPlaylistSheet: View {
         }
     }
     
+    private var cancelButton: some View {
+        Button("Cancel".localized()) {
+            presentationMode.wrappedValue.dismiss()
+        }
+    }
+    
     private var saveButton: some View {
         Button("Save".localized()) {
-            save()
+            viewModel.persistence.savePlaylist(name: name, emoji: emoji)
             presentationMode.wrappedValue.dismiss()
         }
         .tint(.blue)
@@ -149,16 +156,6 @@ struct AddPlaylistSheet: View {
             .onReceive(Just(emoji), perform: { _ in
                 self.emoji = String(self.emoji.onlyEmoji().prefix(MaxCharLength.emojis))
             })
-    }
-    
-    // MARK: - Functions
-    
-    private func save() {
-        let newPlaylist = Playlist(context: CoreDataStack.shared.context)
-        newPlaylist.id = UUID()
-        newPlaylist.name = name
-        newPlaylist.emoji = emoji
-        CoreDataStack.shared.save()
     }
     
     private func moveDown() {

--- a/My Spot/View/Sub View/Playlist/PlaylistSubviewsFactory.swift
+++ b/My Spot/View/Sub View/Playlist/PlaylistSubviewsFactory.swift
@@ -1,0 +1,86 @@
+//
+//  PlaylistSubviewsFactory.swift
+//  My Spot
+//
+//  Created by Raphael Monteiro on 29/06/22.
+//
+
+import SwiftUI
+
+struct PlaylistSubviewsFactory {
+    
+    @ObservedObject var viewModel: PlaylistViewModel
+    
+    func makeListPlaylists() -> some View {
+        List {
+            ForEach(viewModel.persistence.playlists) { playlist in
+                NavigationLink(destination: DetailPlaylistView(playlist: playlist)) {
+                    PlaylistRow(playlist: playlist,
+                                isShared: viewModel.hasOnePart(playlist: playlist),
+                                isSharing: viewModel.isSharing(playlist: playlist))
+                    .alert(isPresented: $viewModel.presentDeleteAlert) {
+                        viewModel.removePlaylistAlert
+                    }
+                }
+            }
+            .onDelete(perform: viewModel.deleteRow)
+            .onAppear(perform: resetBadges)
+        }
+    }
+    
+    func makeAddPlaylistButton() -> some View {
+        Button {
+            viewModel.presentAddPlaylistSheet.toggle()
+        } label: {
+            Image(systemName: "plus").imageScale(.large)
+        }
+    }
+    
+    func makeNoPlaylistPrompt() -> some View {
+        VStack(spacing: 6) {
+            makeNoPlaylistPromptTitle()
+            makeNoPlaylistPromptSubtitle()
+        }
+    }
+    
+    private func makeNoPlaylistPromptTitle() -> some View {
+        HStack {
+            Spacer()
+            Text("No Playlists Here Yet!".localized())
+            Spacer()
+        }
+    }
+    
+    private func makeNoPlaylistPromptSubtitle() -> some View {
+        HStack {
+            Spacer()
+            HStack {
+                Text("Add Some With The".localized())
+                    .font(.subheadline)
+                    .foregroundColor(.gray)
+                Image(systemName: "plus")
+                    .font(.subheadline)
+                    .foregroundColor(.gray)
+                Text("Button Above".localized())
+                    .font(.subheadline)
+                    .foregroundColor(.gray)
+            }
+            Spacer()
+        }
+    }
+    
+    private func resetBadges() {
+        UserDefaults.standard.set(0, forKey: "badgeplaylists")
+        viewModel.cloudViewModel.resetBadgePlaylists()
+    }
+    
+    func makeAlertInvalidPermission() -> Alert {
+        Alert(
+            title: Text("Invalid Permission".localized()),
+            message: Text("Only the owner can delete. If you would like to leave the shared playlist, please tap the person icon and choose yourself.".localized()),
+            dismissButton: .cancel()
+        )
+    }
+    
+}
+

--- a/My Spot/ViewModel/PlaylistViewModel.swift
+++ b/My Spot/ViewModel/PlaylistViewModel.swift
@@ -1,0 +1,60 @@
+//
+//  PlaylistViewModel.swift
+//  My Spot
+//
+//  Created by Raphael Monteiro on 28/06/22.
+//
+
+import SwiftUI
+
+final class PlaylistViewModel: ObservableObject {
+    
+    @ObservedObject var persistence = PlaylistPersistenceManager()
+    @ObservedObject var mapViewModel: MapViewModel
+    @ObservedObject var cloudViewModel: CloudKitViewModel
+    
+    @Published var presentDeleteAlert = false
+    @Published var presentAddPlaylistSheet = false
+    @Published var presentNoPermissionsAlert = false
+    var playlistToDelete: Playlist?
+    
+    init(mapViewModel: MapViewModel, cloudViewModel: CloudKitViewModel) {
+        self.mapViewModel = mapViewModel
+        self.cloudViewModel = cloudViewModel
+        persistence.loadPlaylists()
+    }
+    
+    func hasOnePart(playlist: Playlist) -> Bool {
+        var isShared = false
+        if CoreDataStack.shared.isShared(object: playlist) {
+            let share = CoreDataStack.shared.getShare(playlist)
+            share?.participants.forEach { participant in
+                if (participant.acceptanceStatus == .accepted && participant.role != .owner) {
+                    isShared = true
+                }
+            }
+        }
+        return isShared
+    }
+    
+    func isSharing(playlist: Playlist) -> Bool {
+        return CoreDataStack.shared.isShared(object: playlist)
+    }
+    
+    func deleteRow(at indexSet: IndexSet) {
+        self.presentDeleteAlert = true
+        playlistToDelete = persistence.playlists[indexSet.first!]
+    }
+    
+    var removePlaylistAlert: Alert {
+        Alert(title: Text("Are you sure you want to delete?".localized()),
+              message: Text("If you are the owner of a shared playlist, all participants will no longer have access.".localized()),
+              primaryButton: .destructive(Text("Delete".localized())) {
+            self.persistence.delete(self.playlistToDelete!)
+        }, secondaryButton: .cancel() {
+            self.presentDeleteAlert = false
+        }
+        )
+    }
+    
+}


### PR DESCRIPTION
- Simplified PlaylistView.swift considerably creating a ViewModel class for its logic, and a Factory struct for its subviews;
- Created an _**initial**_ unit test file for PlaylistViewModel.swift and its isolated persistence methods.

As you said before, your original CoreDataManager.swift may be a little bit longer, but I prefer not to touch that because you should study it deeply and decide what is better. 
In this PR, I isolated the persistence related to entity Playlist to keep a class dedicated to that intent. It's my suggestion about an approach to lead with persistence (S of SOLID), and not a singleton with full responsibility over all entities.